### PR TITLE
Fix plugin menu registration

### DIFF
--- a/auto-patrol-manager.js
+++ b/auto-patrol-manager.js
@@ -155,9 +155,11 @@
     authors: META.authors,
     type: META.type,
     targetApiVersion: META.targetApiVersion,
-    licence: "MIT",
+    license: "MIT",
     main() {
-      ui.registerMenuItem(META.name, openWindow);
+      if (typeof ui !== "undefined" && ui && ui.registerMenuItem) {
+        ui.registerMenuItem(META.name, openWindow);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Guard menu registration on presence of `ui` to prevent startup errors when UI isn't available
- Correct plugin metadata to use `license` field

## Testing
- `node - <<'NODE'
  global.registerPlugin = function(obj){ console.log('registered', obj.name); obj.main(); };
  const mockUI = { registerMenuItem: (name, fn)=>console.log('menu item', name) };
  global.ui = mockUI;
  require('./auto-patrol-manager.js');
  NODE`
- `node - <<'NODE'
  global.registerPlugin = function(obj){ console.log('registered', obj.name); obj.main(); };
  // ui is intentionally undefined
  require('./auto-patrol-manager.js');
  NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b2ef1e5c04832d929b8338f1d6c442