### PR TITLE
Fix plugin menu registration

### DIFF
--- a/auto-patrol-manager.js
+++ b/auto-patrol-manager.js
@@ -155,9 +155,23 @@
     authors: META.authors,
     type: META.type,
     targetApiVersion: META.targetApiVersion,
-    licence: "MIT",
+    license: "MIT",
     main() {
-      ui.registerMenuItem(META.name, openWindow);
+      const attemptRegister = () => {
+        if (typeof ui !== "undefined" && ui && ui.registerMenuItem) {
+          ui.registerMenuItem(META.name, openWindow);
+          return true;
+        }
+        return false;
+      };
+
+      if (!attemptRegister() && typeof context !== "undefined" && context && context.subscribe) {
+        const intervalId = context.subscribe("interval", () => {
+          if (attemptRegister() && context.unsubscribe) {
+            context.unsubscribe(intervalId);
+          }
+        });
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Guard menu registration on presence of `ui` to prevent startup errors when UI isn't available
- Correct plugin metadata to use `license` field
- Retry menu registration periodically until `ui` becomes available

## Testing
- `node - <<'NODE'
  global.registerPlugin = function(obj){ console.log('registered', obj.name); obj.main(); };
  const mockUI = { registerMenuItem: (name, fn)=>console.log('menu item', name) };
  global.ui = mockUI;
  require('./auto-patrol-manager.js');
  NODE`
- `node - <<'NODE'
  let intervalCb;
  global.registerPlugin = function(obj){ console.log('registered', obj.name); obj.main(); };
  global.context = {
    subscribe: function(ev, cb){ console.log('subscribed', ev); intervalCb = cb; return 1; },
    unsubscribe: function(id){ console.log('unsub', id); }
  };
  require('./auto-patrol-manager.js');
  console.log('after load');
  const mockUI = { registerMenuItem: (name, fn)=>console.log('menu item', name) };
  global.ui = mockUI;
  intervalCb();
  NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef1e5c04832d929b8338f1d6c442